### PR TITLE
Fix action version reference from v1 to v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ehmo/repo-tokens@v1
+      - uses: ehmo/repo-tokens@v0.1.0
         id: tokens
 
       - name: Commit if changed

--- a/cmd/repo-tokens/init.go
+++ b/cmd/repo-tokens/init.go
@@ -90,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ehmo/repo-tokens@v1
+      - uses: ehmo/repo-tokens@v0.1.0
         id: tokens
 
       - name: Commit if changed


### PR DESCRIPTION
## Summary
- The README and `init` command reference `ehmo/repo-tokens@v1`, but the actual release is `v0.1.0`
- Updated both `README.md` and `cmd/repo-tokens/init.go` to use `@v0.1.0`

Fixes #1