### PR TITLE
Display badge image in README instead of plain text

### DIFF
--- a/cmd/repo-tokens/action.go
+++ b/cmd/repo-tokens/action.go
@@ -55,7 +55,7 @@ func runAction() {
 			if url == "" {
 				url = "https://github.com/ehmo/repo-tokens"
 			}
-			if ok, err := readme.UpdateMarkers(readmePath, marker, text, url); err != nil {
+			if ok, err := readme.UpdateMarkers(readmePath, marker, text, url, badgePath); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: readme: %v\n", err)
 			} else if ok {
 				fmt.Println("README updated")

--- a/cmd/repo-tokens/main.go
+++ b/cmd/repo-tokens/main.go
@@ -122,7 +122,7 @@ func main() {
 			url = "https://github.com/ehmo/repo-tokens"
 		}
 		text := badge.Text(s.TotalTokens, s.ContextWindow)
-		if ok, err := readme.UpdateMarkers(updReadme, marker, text, url); err != nil {
+		if ok, err := readme.UpdateMarkers(updReadme, marker, text, url, badgePath); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: readme: %v\n", err)
 		} else if ok {
 			fmt.Printf("\nREADME updated: %s\n", updReadme)

--- a/internal/readme/readme.go
+++ b/internal/readme/readme.go
@@ -9,7 +9,7 @@ import (
 
 // UpdateMarkers replaces content between <!-- marker --> and <!-- /marker -->.
 // Returns true if the file was modified.
-func UpdateMarkers(path, marker, text, linkURL string) (bool, error) {
+func UpdateMarkers(path, marker, text, linkURL, badgeImgPath string) (bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return false, err
@@ -22,8 +22,13 @@ func UpdateMarkers(path, marker, text, linkURL string) (bool, error) {
 		return false, err
 	}
 
-	linked := fmt.Sprintf(`<a href="%s">%s</a>`, linkURL, text)
-	updated := re.ReplaceAllString(content, "${1}"+linked+"${2}")
+	var replacement string
+	if badgeImgPath != "" {
+		replacement = fmt.Sprintf(`<a href="%s"><img src="%s" alt="%s"></a>`, linkURL, badgeImgPath, text)
+	} else {
+		replacement = fmt.Sprintf(`<a href="%s">%s</a>`, linkURL, text)
+	}
+	updated := re.ReplaceAllString(content, "${1}"+replacement+"${2}")
 	if updated == content {
 		return false, nil
 	}

--- a/internal/readme/readme.go
+++ b/internal/readme/readme.go
@@ -24,9 +24,9 @@ func UpdateMarkers(path, marker, text, linkURL, badgeImgPath string) (bool, erro
 
 	var replacement string
 	if badgeImgPath != "" {
-		replacement = fmt.Sprintf(`<a href="%s"><img src="%s" alt="%s"></a>`, linkURL, badgeImgPath, text)
+		replacement = fmt.Sprintf(`[![%s](%s)](%s)`, text, badgeImgPath, linkURL)
 	} else {
-		replacement = fmt.Sprintf(`<a href="%s">%s</a>`, linkURL, text)
+		replacement = fmt.Sprintf(`[%s](%s)`, text, linkURL)
 	}
 	updated := re.ReplaceAllString(content, "${1}"+replacement+"${2}")
 	if updated == content {


### PR DESCRIPTION
## Summary
- `UpdateMarkers` now renders an `<img>` tag pointing to the SVG badge with the token count text as alt text
- Falls back to plain text `<a>` link when no badge path is provided (CLI without `--badge`)

Fixes #3